### PR TITLE
Olympians by Age Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,57 @@ GET api/v1/olympians
   ]
 }
 ```
+### GET `api/v1/olympians?age=YOUNGEST_OR_OLDEST`
+- This GET request returns the Youngest or Oldest in Age of all stored Olympians, serialized to include the following information:
+- - Name
+- - Team
+- - Age
+- - Sport
+- - Total Number of Medals Won
+- Example Request:
+```
+GET api/v1/olympians?age=youngest
+```
+- Example Response:
+```json
+{
+  "data": [
+    {
+      "id": null,
+      "type": "olympian",
+      "attributes": {
+        "name": "Ana Iulia Dascl",
+        "team": "Romania",
+        "age": 13,
+        "sport": "Swimming",
+        "total_medals_won": 0
+      }
+    }
+  ]
+}
+```
+- Example Request:
+```
+GET api/v1/olympians?age=oldest
+```
+- Example Response:
+```json
+{
+  "data": [
+    {
+      "id": null,
+      "type": "olympian",
+      "attributes": {
+        "name": "Julie Brougham",
+        "team": "New Zealand",
+        "age": 62,
+        "sport": "Equestrianism",
+        "total_medals_won": 0
+      }
+    }
+  ]
+}
+```
 
 ## Contributing
 - Koroibos Olympian Analytics uses Travis CI to ensure project stability. Travis is one of our required checks, and is performed on new PRs. Your code can not be merged in if there are failing specs.

--- a/app/controllers/api/v1/olympians_controller.rb
+++ b/app/controllers/api/v1/olympians_controller.rb
@@ -6,6 +6,7 @@ module Api
     class OlympiansController < ApplicationController
       def index
         age = 'ASC' if params[:age] == 'youngest'
+        age = 'DESC' if params[:age] == 'oldest'
         render json: OlympianSerializer.new(Olympian.all_with_total_medals_won(age))
       end
     end

--- a/app/controllers/api/v1/olympians_controller.rb
+++ b/app/controllers/api/v1/olympians_controller.rb
@@ -7,7 +7,8 @@ module Api
       def index
         age = 'ASC' if params[:age] == 'youngest'
         age = 'DESC' if params[:age] == 'oldest'
-        render json: OlympianSerializer.new(Olympian.all_with_total_medals_won(age))
+        json = OlympianSerializer.new(Olympian.all_with_total_medals_won(age))
+        render json: json
       end
     end
   end

--- a/app/controllers/api/v1/olympians_controller.rb
+++ b/app/controllers/api/v1/olympians_controller.rb
@@ -5,7 +5,8 @@ module Api
     # The Olympians controller handles all RESTful routes for the Olympians table
     class OlympiansController < ApplicationController
       def index
-        render json: OlympianSerializer.new(Olympian.all_with_total_medals_won)
+        age = 'ASC' if params[:age] == 'youngest'
+        render json: OlympianSerializer.new(Olympian.all_with_total_medals_won(age))
       end
     end
   end

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -15,6 +15,6 @@ class Olympian < ApplicationRecord
     )
       .group(:name, :team, :age, :sport)
       .order(:name)
-    !age.nil? ? olympians.order(age: age).limit(1) : olympians
+    !age.nil? ? olympians.unscope(:order).order(age: age).limit(1) : olympians
   end
 end

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -5,8 +5,8 @@
 class Olympian < ApplicationRecord
   validates_presence_of :name, :sex, :age, :team, :games, :sport, :event
 
-  def self.all_with_total_medals_won
-    select(
+  def self.all_with_total_medals_won(age = nil)
+    olympians = select(
       'olympians.name,
       olympians.team,
       olympians.age,
@@ -15,5 +15,6 @@ class Olympian < ApplicationRecord
     )
       .group(:name, :team, :age, :sport)
       .order(:name)
+    !age.nil? ? olympians.order(age: age).limit(1) : olympians
   end
 end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -34,5 +34,15 @@ RSpec.describe Olympian, type: :model do
       expect(olympians.first.total_medals_won).to eq(2)
       expect(olympians.last.total_medals_won).to eq(0)
     end
+
+    it "should return the youngest Olympian with ::all_with_total_medals_won('ASC')" do
+      expect(Olympian.all.length).to eq(5)
+      youngest = Olympian.all_with_total_medals_won('ASC')
+      expect(youngest.length).to eq(1)
+      expect(youngest.first.name).to eq('Brian Plantico')
+      expect(youngest.last.name).to_not eq('Logan Pile')
+      expect(youngest.first.total_medals_won).to eq(2)
+      expect(youngest.last.total_medals_won).to_not eq(0)
+    end
   end
 end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -44,5 +44,15 @@ RSpec.describe Olympian, type: :model do
       expect(youngest.first.total_medals_won).to eq(2)
       expect(youngest.last.total_medals_won).to_not eq(0)
     end
+
+    it "should return the oldest Olympian with ::all_with_total_medals_won('DESC')" do
+      expect(Olympian.all.length).to eq(5)
+      oldest = Olympian.all_with_total_medals_won('DESC')
+      expect(oldest.length).to eq(1)
+      expect(oldest.first.name).to_not eq('Brian Plantico')
+      expect(oldest.last.name).to eq('Logan Pile')
+      expect(oldest.first.total_medals_won).to_not eq(2)
+      expect(oldest.last.total_medals_won).to eq(0)
+    end
   end
 end

--- a/spec/requests/api/v1/olympians_spec.rb
+++ b/spec/requests/api/v1/olympians_spec.rb
@@ -62,4 +62,26 @@ describe 'Olympian API' do
     expect(olympian.first['attributes']['sport']).to eq('Cycling')
     expect(olympian.first['attributes']['total_medals_won']).to eq(2)
   end
+
+  it 'should return the oldest Olympian with pertinent information' do
+    create(:olympian, name: 'Brian Plantico', team: 'Wisconsin', age: 17, sport: 'Cycling', medal: 'Gold')
+    create(:olympian, name: 'Brian Plantico', team: 'Wisconsin', age: 17, sport: 'Cycling', medal: 'Silver')
+    create(:olympian, name: 'Brian Plantico', team: 'Wisconsin', age: 17, sport: 'Cycling', event: 'The Downhill')
+    create(:olympian, name: 'Logan Pile', team: 'Colorado', age: 55, sport: 'Wakeboarding', event: 'Sick Waves')
+    create(:olympian, name: 'Logan Pile', team: 'Colorado', age: 55, sport: 'Wakeboarding', event: 'Not So Sick Waves')
+    create(:olympian, name: 'Earl Stephens', team: 'Florida', age: 34, sport: 'Boxing', event: 'VS Mike Tyson')
+
+    get '/api/v1/olympians?age=oldest'
+
+    expect(response).to be_successful
+
+    olympian = JSON.parse(response.body)['data']
+
+    expect(olympian.length).to eq(1)
+    expect(olympian.first['attributes']['name']).to eq('Logan Pile')
+    expect(olympian.first['attributes']['team']).to eq('Colorado')
+    expect(olympian.first['attributes']['age']).to eq(55)
+    expect(olympian.first['attributes']['sport']).to eq('Wakeboarding')
+    expect(olympian.first['attributes']['total_medals_won']).to eq(0)
+  end
 end

--- a/spec/requests/api/v1/olympians_spec.rb
+++ b/spec/requests/api/v1/olympians_spec.rb
@@ -40,4 +40,26 @@ describe 'Olympian API' do
     expect(olympians.last['attributes']['sport']).to eq('Wakeboarding')
     expect(olympians.last['attributes']['total_medals_won']).to eq(0)
   end
+
+  it 'should return the youngest Olympian with pertinent information' do
+    create(:olympian, name: 'Brian Plantico', team: 'Wisconsin', age: 17, sport: 'Cycling', medal: 'Gold')
+    create(:olympian, name: 'Brian Plantico', team: 'Wisconsin', age: 17, sport: 'Cycling', medal: 'Silver')
+    create(:olympian, name: 'Brian Plantico', team: 'Wisconsin', age: 17, sport: 'Cycling', event: 'The Downhill')
+    create(:olympian, name: 'Logan Pile', team: 'Colorado', age: 55, sport: 'Wakeboarding', event: 'Sick Waves')
+    create(:olympian, name: 'Logan Pile', team: 'Colorado', age: 55, sport: 'Wakeboarding', event: 'Not So Sick Waves')
+    create(:olympian, name: 'Earl Stephens', team: 'Florida', age: 34, sport: 'Boxing', event: 'VS Mike Tyson')
+
+    get '/api/v1/olympians?age=youngest'
+
+    expect(response).to be_successful
+
+    olympian = JSON.parse(response.body)['data']
+
+    expect(olympian.length).to eq(1)
+    expect(olympian.first['attributes']['name']).to eq('Brian Plantico')
+    expect(olympian.first['attributes']['team']).to eq('Wisconsin')
+    expect(olympian.first['attributes']['age']).to eq(17)
+    expect(olympian.first['attributes']['sport']).to eq('Cycling')
+    expect(olympian.first['attributes']['total_medals_won']).to eq(2)
+  end
 end


### PR DESCRIPTION
# Pull Request Template

## Description

This PR brings in the functionality for our `olympians` endpoint to take in a parameter of `age`, either having a value of `youngest` or `oldest`, which then will provide the respective Olympian. The formatting of the Olympian is the same as when the endpoint returns all Olympians.
- Name
- Team
- Age
- Sport
- Total Medals Won
This required a refactor of the OlympiansController flow, as the `index` action would sometimes be taking a parameter, but sometimes would not. We had to check to see if the parameter was there, and if it was, what the value was. If it matched the `youngest` or `oldest` parameters, we would pass `ASC` or `DESC` respectively into `::all_with_total_medals_won`. Otherwise, the method would return all Olympian records.
This does not directly follow RESTful conventions, but it is what was requested of the spec. To address these concerns at a later time, please refer to #28 .

Resolves #5 
Resolves #6 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Olympians endpoint spec with `age=youngest` param
- [x] Olympians endpoint spec with `age=oldest` param
- [x] Olympians `::all_with_total_medals_won` model spec with `ASC`
- [x] Olympians `::all_with_total_medals_won` model spec with `DESC`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
