### PR TITLE
Olympian stats endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,36 @@ GET api/v1/olympians?age=oldest
   ]
 }
 ```
+### GET `api/v1/olympian_stats`
+- This GET request returns statistical information for all Olympians stored in the database. This includes the following:
+- - Total Olympians Competing
+- - Average Weight of Male Olympians (in kg)
+- - Average Weight of Female Olympians (in kg)
+- - Average Age of all Olympians
+- Example Request:
+```
+GET api/v1/olympian_stats
+```
+- Example Response:
+```json
+{
+  "data": [
+    {
+      "id": null,
+      "type": "olympian_stats",
+      "attributes": {
+        "total_competing_olympians": 2850,
+        "average_age": "26.2",
+        "average_weight": {
+          "unit": "kg",
+          "male_olympians": "78.6",
+          "female_olympians": "61.9"
+        }
+      }
+    }
+  ]
+}
+```
 
 ## Contributing
 - Koroibos Olympian Analytics uses Travis CI to ensure project stability. Travis is one of our required checks, and is performed on new PRs. Your code can not be merged in if there are failing specs.

--- a/app/controllers/api/v1/olympian_stats_controller.rb
+++ b/app/controllers/api/v1/olympian_stats_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    # The OlympianStats controller handles finding and returning statistics
+    # about all Olympians included in the database
+    class OlympianStatsController < ApplicationController
+      def index
+        json = OlympianStatsSerializer.new(Olympian.statistics)
+        render json: json
+      end
+    end
+  end
+end

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -17,4 +17,11 @@ class Olympian < ApplicationRecord
       .order(:name)
     !age.nil? ? olympians.unscope(:order).order(age: age).limit(1) : olympians
   end
+
+  def self.statistics
+    select("COUNT (DISTINCT name) AS total_competing_olympians,
+    AVG (age) AS average_age,
+    AVG (CASE WHEN sex = 'M' THEN weight END) AS male_olympians,
+    AVG (CASE WHEN sex = 'F' THEN weight END) AS female_olympians")
+  end
 end

--- a/app/serializers/olympian_stats_serializer.rb
+++ b/app/serializers/olympian_stats_serializer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# A FastJSON API Serializer to take in an Olympian Stats object and
+# return only the required attributes
+class OlympianStatsSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :total_competing_olympians
+
+  attribute :average_age do |object|
+    object.average_age.round(1)
+  end
+
+  attribute :average_weight do |object|
+    {
+      unit: 'kg',
+      male_olympians: object.male_olympians.round(1),
+      female_olympians: object.female_olympians.round(1)
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :olympians, only: [:index]
+      get 'olympian_stats', to: 'olympian_stats#index'
     end
   end
 end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -18,11 +18,11 @@ RSpec.describe Olympian, type: :model do
 
   describe 'class methods' do
     before :each do
-      create(:olympian, name: 'Brian Plantico', team: 'Wisconsin', age: 17, sport: 'Cycling', medal: 'Gold')
-      create(:olympian, name: 'Brian Plantico', team: 'Wisconsin', age: 17, sport: 'Cycling', medal: 'Silver')
-      create(:olympian, name: 'Brian Plantico', team: 'Wisconsin', age: 17, sport: 'Cycling', event: 'The Downhill')
-      create(:olympian, name: 'Logan Pile', team: 'Colorado', age: 55, sport: 'Wakeboarding', event: 'Sick Waves')
-      create(:olympian, name: 'Logan Pile', team: 'Colorado', age: 55, sport: 'Wakeboarding', event: 'Not So Sick Waves')
+      create(:olympian, name: 'Brian Plantico', sex: 'M', team: 'Wisconsin', age: 17, weight: 70, sport: 'Cycling', medal: 'Gold')
+      create(:olympian, name: 'Brian Plantico', sex: 'M', team: 'Wisconsin', age: 17, weight: 70, sport: 'Cycling', medal: 'Silver')
+      create(:olympian, name: 'Brian Plantico', sex: 'M', team: 'Wisconsin', age: 17, weight: 70, sport: 'Cycling', event: 'The Downhill')
+      create(:olympian, name: 'Logan Pile', sex: 'M', team: 'Colorado', age: 55, weight: 60, sport: 'Wakeboarding', event: 'Sick Waves')
+      create(:olympian, name: 'Logan Pile', sex: 'M', team: 'Colorado', age: 55, weight: 60, sport: 'Wakeboarding', event: 'Not So Sick Waves')
     end
 
     it 'should return collated Olympians with ::all_with_total_medals_won' do
@@ -53,6 +53,16 @@ RSpec.describe Olympian, type: :model do
       expect(oldest.last.name).to eq('Logan Pile')
       expect(oldest.first.total_medals_won).to_not eq(2)
       expect(oldest.last.total_medals_won).to eq(0)
+    end
+
+    it 'should return the statistics for all Olympians in the database with ::statistics' do
+      create(:olympian, name: 'Alexandra Chakres', sex: 'F', age: 34, weight: 55)
+      expect(Olympian.all.length).to eq(6)
+      stats = Olympian.statistics.take
+      expect(stats.total_competing_olympians).to eq(3)
+      expect(stats.male_olympians).to eq(66.0)
+      expect(stats.female_olympians).to eq(55.0)
+      expect(stats.average_age).to eq(32.5)
     end
   end
 end

--- a/spec/requests/api/v1/olympian_stats_spec.rb
+++ b/spec/requests/api/v1/olympian_stats_spec.rb
@@ -11,7 +11,7 @@ describe 'Olympian Stats` API' do
     create(:olympian, name: 'Alexandra Chakres', age: 55, weight: 55, sex: 'F')
     create(:olympian, name: 'Earl Stephens', age: 34, weight: 70, sex: 'M')
 
-    get "/api/v1/olympian_stats"
+    get '/api/v1/olympian_stats'
 
     expect(response).to be_successful
 
@@ -19,8 +19,8 @@ describe 'Olympian Stats` API' do
 
     expect(stats['total_competing_olympians']).to eq(3)
     expect(stats['average_weight']['unit']).to eq('kg')
-    expect(stats['average_weight']['male_olympians']).to eq("62.5")
-    expect(stats['average_weight']['female_olympians']).to eq("55.0")
-    expect(stats['average_age']).to eq("32.5")
+    expect(stats['average_weight']['male_olympians']).to eq('62.5')
+    expect(stats['average_weight']['female_olympians']).to eq('55.0')
+    expect(stats['average_age']).to eq('32.5')
   end
 end

--- a/spec/requests/api/v1/olympian_stats_spec.rb
+++ b/spec/requests/api/v1/olympian_stats_spec.rb
@@ -1,13 +1,15 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe 'Olympian Stats` API' do
   it 'sends a response with stats for all stored Olympians' do
-    create(:olympian, name: 'Brian Plantico', age: 17, weight: 60)
-    create(:olympian, name: 'Brian Plantico', age: 17, weight: 60)
-    create(:olympian, name: 'Brian Plantico', age: 17, weight: 60)
-    create(:olympian, name: 'Alexandra Chakres', age: 55, weight: 55)
-    create(:olympian, name: 'Alexandra Chakres', age: 55, weight: 55)
-    create(:olympian, name: 'Earl Stephens', age: 34, weight: 70)
+    create(:olympian, name: 'Brian Plantico', age: 17, weight: 60, sex: 'M')
+    create(:olympian, name: 'Brian Plantico', age: 17, weight: 60, sex: 'M')
+    create(:olympian, name: 'Brian Plantico', age: 17, weight: 60, sex: 'M')
+    create(:olympian, name: 'Alexandra Chakres', age: 55, weight: 55, sex: 'F')
+    create(:olympian, name: 'Alexandra Chakres', age: 55, weight: 55, sex: 'F')
+    create(:olympian, name: 'Earl Stephens', age: 34, weight: 70, sex: 'M')
 
     get "/api/v1/olympian_stats"
 
@@ -17,8 +19,8 @@ describe 'Olympian Stats` API' do
 
     expect(stats['total_competing_olympians']).to eq(3)
     expect(stats['average_weight']['unit']).to eq('kg')
-    expect(stats['average_weight']['male_olympians']).to eq(65.0)
-    expect(stats['average_weight']['female_olympians']).to eq(55.0)
-    expect(stats['average_age']).to eq(35.3)
+    expect(stats['average_weight']['male_olympians']).to eq("62.5")
+    expect(stats['average_weight']['female_olympians']).to eq("55.0")
+    expect(stats['average_age']).to eq("32.5")
   end
 end

--- a/spec/requests/api/v1/olympian_stats_spec.rb
+++ b/spec/requests/api/v1/olympian_stats_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe 'Olympian Stats` API' do
+  it 'sends a response with stats for all stored Olympians' do
+    create(:olympian, name: 'Brian Plantico', age: 17, weight: 60)
+    create(:olympian, name: 'Brian Plantico', age: 17, weight: 60)
+    create(:olympian, name: 'Brian Plantico', age: 17, weight: 60)
+    create(:olympian, name: 'Alexandra Chakres', age: 55, weight: 55)
+    create(:olympian, name: 'Alexandra Chakres', age: 55, weight: 55)
+    create(:olympian, name: 'Earl Stephens', age: 34, weight: 70)
+
+    get "/api/v1/olympian_stats"
+
+    expect(response).to be_successful
+
+    stats = JSON.parse(response.body)['data'].first['attributes']
+
+    expect(stats['total_competing_olympians']).to eq(3)
+    expect(stats['average_weight']['unit']).to eq('kg')
+    expect(stats['average_weight']['male_olympians']).to eq(65.0)
+    expect(stats['average_weight']['female_olympians']).to eq(55.0)
+    expect(stats['average_age']).to eq(35.3)
+  end
+end


### PR DESCRIPTION
# Pull Request Template

## Description

This PR brings in the Olympian Stats endpoint, which provides us a set of statistics for all Olympians stored in the database. The attributes that are focused on are:
- Number of total Olympians competing
- Average Age of all Olympians
- Average Weight of Male and Female Olympians separately
This performs some SQL `COUNT` and `AVG` calls on the Olympians table to find this information. It `COUNT`s the `DISTINCT` Olympian `name`s to determine how many individuals participated. It `AVG`s the `weight`s when `sex = 'M'` or `sex = 'F'` respectively to determine those values. It performs an `AVG` on the `age`s to determine that value.

Resolves #7 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Olympian Stats Endpoint spec
- [x] Olympian `::statistics` model spec

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
